### PR TITLE
Model nonlinear Burgers propagation for explosion synthesis

### DIFF
--- a/tests_burgers.py
+++ b/tests_burgers.py
@@ -1,0 +1,44 @@
+import numpy as np
+from explosion import AtmosphereWT, Geometry, Ordnance, Rendering, synthesize_explosion
+
+
+def _rise_time(w, sr):
+    idx = int(np.argmax(w))
+    peak = w[idx]
+    th = 0.1 * peak
+    pre = w[:idx]
+    start = np.where(pre >= th)[0][0]
+    return (idx - start) / sr
+
+
+def _max_slope(w, sr):
+    return np.max(np.abs(np.diff(w))) * sr
+
+
+def _time_to_neg(w, sr):
+    idx = int(np.argmax(w))
+    neg_idx = idx + np.argmin(w[idx: idx + int(0.05 * sr)])
+    return (neg_idx - idx) / sr
+
+
+def _render(distance, sr, use_burgers):
+    ord = Ordnance(10.0)
+    geo = Geometry(source=(0.0, 0.0, 1.0), receiver=(distance, 0.0, 1.7))
+    atmos = AtmosphereWT(rh=0.5)
+    return synthesize_explosion(ord, geo, atmos, Rendering(sample_rate=sr, pad=0.1, use_burgers=use_burgers))
+
+
+def test_burgers_50m():
+    sr = 16000
+    w_lin = _render(50.0, sr, False)
+    w_nl = _render(50.0, sr, True)
+    assert _max_slope(w_nl, sr) > _max_slope(w_lin, sr)
+    assert _time_to_neg(w_nl, sr) < _time_to_neg(w_lin, sr)
+
+
+def test_burgers_200m():
+    sr = 16000
+    w_lin = _render(200.0, sr, False)
+    w_nl = _render(200.0, sr, True)
+    assert _rise_time(w_nl, sr) < _rise_time(w_lin, sr)
+    assert _time_to_neg(w_nl, sr) < _time_to_neg(w_lin, sr)

--- a/tests_tv.py
+++ b/tests_tv.py
@@ -20,7 +20,7 @@ def test_static_regression():
     ord = Ordnance(10.0, re=1.0, height_of_burst=0.0)
     geo = Geometry(source=(0.0, 0.0, 1.0), receiver=(100.0, 0.0, 1.7))
     atmos = AtmosphereWT(rh=0.5)
-    render = Rendering(sample_rate=8000, pad=0.2)
+    render = Rendering(sample_rate=8000, pad=0.2, use_burgers=False)
     w_static = synthesize_explosion(ord, geo, atmos, render)
     w_tv = synthesize_explosion_tv(ord, geo, atmos, render)
     idx = np.argmax(np.abs(w_static))
@@ -36,7 +36,7 @@ def test_doppler_glide():
     src = LinearMotion((-300.0, 0.0, 50.0), (200.0, 0.0, 0.0))
     geo = Geometry(source=src, receiver=(0.0, 0.0, 1.7))
     atmos = AtmosphereWT(rh=0.5)
-    render = Rendering(sample_rate=8000, pad=0.2)
+    render = Rendering(sample_rate=8000, pad=0.2, use_burgers=False)
     y = synthesize_explosion(ord, geo, atmos, render)
     f, t, S = spectrogram(y, fs=render.sample_rate, nperseg=512, noverlap=256)
     ridge = f[np.argmax(S, axis=0)]
@@ -56,7 +56,7 @@ def test_energy_falloff():
     rec_motion = LinearMotion((50.0, 0.0, 1.7), (100.0, 0.0, 0.0))
     geo = Geometry(source=src, receiver=rec_motion)
     atmos = AtmosphereWT(rh=0.0)
-    render = Rendering(sample_rate=8000, pad=0.2)
+    render = Rendering(sample_rate=8000, pad=0.2, use_burgers=False)
     import explosion
 
     orig_design = explosion.design_absorption_fir
@@ -80,7 +80,7 @@ def test_ground_image_on_off():
     geo_soft = Geometry(source=src, receiver=rec, flow_resistivity=5e4)
     geo_rigid = Geometry(source=src, receiver=rec, flow_resistivity=1e12)
     atmos = AtmosphereWT(rh=0.5)
-    render = Rendering(sample_rate=8000, pad=0.2)
+    render = Rendering(sample_rate=8000, pad=0.2, use_burgers=False)
     y_soft = synthesize_explosion_tv(ord, geo_soft, atmos, render)
     y_rigid = synthesize_explosion_tv(ord, geo_rigid, atmos, render)
     idx = np.argmax(np.abs(y_rigid))


### PR DESCRIPTION
## Summary
- add optional `propagate_burgers` solver for weakly nonlinear, lossy propagation
- expose `use_burgers` toggle in `Rendering`
- apply Burgers propagation to direct and ground paths
- add unit tests comparing linear and Burgers propagation at 50m and 200m

## Testing
- `python -m pytest tests_burgers.py -q`
- `python tests_tv.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7cb901cf4832f88b20ae2f885eaeb