### PR TITLE
Add source emission shaping and directivity

### DIFF
--- a/tests_burgers.py
+++ b/tests_burgers.py
@@ -25,7 +25,8 @@ def _render(distance, sr, use_burgers):
     ord = Ordnance(10.0)
     geo = Geometry(source=(0.0, 0.0, 1.0), receiver=(distance, 0.0, 1.7))
     atmos = AtmosphereWT(rh=0.5)
-    return synthesize_explosion(ord, geo, atmos, Rendering(sample_rate=sr, pad=0.1, use_burgers=use_burgers))
+    render = Rendering(sample_rate=sr, pad=0.1, use_burgers=use_burgers, enable_source_shaper=False)
+    return synthesize_explosion(ord, geo, atmos, render)
 
 
 def test_burgers_50m():


### PR DESCRIPTION
## Summary
- model finite charge radius, burst type, and directivity in `Ordnance`
- add minimum-phase source shaper with HOB interference and optional debug output
- apply cosine directivity and shaping per path in synthesis

## Testing
- `python tests_tv.py`
- `python - <<'PY'
from tests_burgers import test_burgers_50m, test_burgers_200m
for fn in (test_burgers_50m, test_burgers_200m):
    fn()
print('tests_burgers passed')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b8434239b0832fa4f53d307501b732