### PR TITLE
feat: add AcousticWorld API and flat world adapter

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from explosion import (
+from explosion_audio.explosion import (
     Ordnance,
     Geometry,
     AtmosphereWT,
@@ -10,6 +10,7 @@ from explosion import (
     synthesize_explosion,
     save_wav,
 )
+from explosion_audio.world.flat import FlatWorld
 
 
 def main() -> None:
@@ -21,13 +22,14 @@ def main() -> None:
     geo1 = Geometry(source=(0, 0, 1.0), receiver=(100.0, 0, 1.7))
     atmos = AtmosphereWT(rh=0.5)
     render = Rendering(sample_rate=96_000, pad=0.5)
-    wave = synthesize_explosion(ord1, geo1, atmos, render)
+    world = FlatWorld(z0=0.0, ground_material_id=2)
+    wave = synthesize_explosion(ord1, geo1, atmos, render, world)
     save_wav(out_dir / "bomb_10kg_100m.wav", render.sample_rate, wave)
 
     # Example 2: 1 kg charge at 20 m with slight height-of-burst
     ord2 = Ordnance(filler_mass=1.0, re=1.0, height_of_burst=2.0)
     geo2 = Geometry(source=(0, 0, 2.0), receiver=(20.0, 0, 1.7))
-    wave2 = synthesize_explosion(ord2, geo2, atmos, render)
+    wave2 = synthesize_explosion(ord2, geo2, atmos, render, world)
     save_wav(out_dir / "shell_1kg_20m.wav", render.sample_rate, wave2)
 
 

--- a/example_tv.py
+++ b/example_tv.py
@@ -1,6 +1,6 @@
 """Example demonstrating time-varying explosion synthesis with motion."""
 
-from explosion import (
+from explosion_audio.explosion import (
     AtmosphereWT,
     Geometry,
     LinearMotion,
@@ -9,6 +9,7 @@ from explosion import (
     save_wav,
     synthesize_explosion,
 )
+from explosion_audio.world.flat import FlatWorld
 
 
 if __name__ == "__main__":
@@ -17,6 +18,7 @@ if __name__ == "__main__":
     geometry = Geometry(source=src_motion, receiver=(0.0, 0.0, 1.7))
     atmos = AtmosphereWT(rh=0.5)
     render = Rendering(sample_rate=96000, pad=1.0)
-    wave = synthesize_explosion(ordnance, geometry, atmos, render)
+    world = FlatWorld(z0=0.0, ground_material_id=2)
+    wave = synthesize_explosion(ordnance, geometry, atmos, render, world)
     save_wav("example_tv.wav", render.sample_rate, wave)
     print("Wrote example_tv.wav")

--- a/explosion_audio/__init__.py
+++ b/explosion_audio/__init__.py
@@ -1,0 +1,4 @@
+"""Explosion audio synthesis package."""
+
+from .explosion import *  # noqa: F401,F403
+from .explosion import __all__ as __all__  # re-export

--- a/explosion_audio/tests/test_burgers.py
+++ b/explosion_audio/tests/test_burgers.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from explosion import AtmosphereWT, Geometry, Ordnance, Rendering, synthesize_explosion
+from ..explosion import AtmosphereWT, Geometry, Ordnance, Rendering, synthesize_explosion
 
 def _rise_time(w, sr):
     idx = int(np.argmax(w))

--- a/explosion_audio/tests/test_flatworld_geom.py
+++ b/explosion_audio/tests/test_flatworld_geom.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from ..world.api import Plane
+from ..world.flat import FlatWorld
+
+
+def test_ground_intersection() -> None:
+    world = FlatWorld(z0=0.0)
+    hit = world.raycast((0.0, 0.0, 10.0), (10.0, 0.0, -10.0))
+    assert hit.hit
+    assert np.allclose(hit.point, (5.0, 0.0, 0.0))
+    assert np.allclose(hit.normal, (0.0, 0.0, 1.0))
+
+
+def test_building_plane_precedence() -> None:
+    plane = Plane((50.0, 0.0, 0.0), (-1.0, 0.0, 0.0))
+    world = FlatWorld(z0=0.0, building_plane=plane)
+    hit = world.raycast((0.0, 0.0, 1.0), (100.0, 0.0, 1.0))
+    assert hit.hit
+    assert np.allclose(hit.point, (50.0, 0.0, 1.0))
+    assert np.allclose(hit.normal, (-1.0, 0.0, 0.0))

--- a/explosion_audio/tests/test_impedance_lookup.py
+++ b/explosion_audio/tests/test_impedance_lookup.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from ..explosion import (
+    AtmosphereWT,
+    Geometry,
+    Ordnance,
+    Rendering,
+    synthesize_explosion,
+)
+from ..world.flat import FlatWorld
+from ..world.materials import default_materials
+
+
+def reflection_amplitude(world: FlatWorld) -> float:
+    ordn = Ordnance(filler_mass=1.0)
+    geo = Geometry(source=(0.0, 0.0, 1.0), receiver=(100.0, 0.0, 1.7))
+    atmos = AtmosphereWT(rh=0.5)
+    render = Rendering(sample_rate=8000, pad=0.2, use_burgers=False)
+    wave = synthesize_explosion(ordn, geo, atmos, render, world)
+    c0 = float(atmos.speed_of_sound(0.0))
+    src = np.array(geo.source, float)
+    rec = np.array(geo.receiver, float)
+    src_img = np.array([src[0], src[1], -src[2]])
+    delay_g = np.linalg.norm(rec - src_img) / c0
+    idx = int(delay_g * render.sample_rate)
+    return float(np.max(np.abs(wave[idx - 5 : idx + 5])))
+
+
+def test_reflection_magnitude_monotonic() -> None:
+    mats = default_materials()
+    pairs = sorted(
+        ((mid, mat.flow_resistivity) for mid, mat in mats.materials.items()),
+        key=lambda m: m[1],
+    )
+    amps = []
+    for mid, _sigma in pairs:
+        world = FlatWorld(z0=0.0, ground_material_id=mid, materials=mats)
+        amps.append(reflection_amplitude(world))
+    assert amps == sorted(amps)

--- a/explosion_audio/tests/test_reflection_plumbing.py
+++ b/explosion_audio/tests/test_reflection_plumbing.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from ..explosion import (
+    AtmosphereWT,
+    Geometry,
+    Ordnance,
+    Rendering,
+    synthesize_explosion,
+)
+from ..world.flat import FlatWorld
+
+
+def test_direct_and_reflected_paths() -> None:
+    world = FlatWorld(z0=0.0, ground_material_id=0)
+    ordn = Ordnance(filler_mass=1.0)
+    geo = Geometry(source=(0.0, 0.0, 1.0), receiver=(100.0, 0.0, 1.7))
+    atmos = AtmosphereWT(rh=0.5)
+    render = Rendering(sample_rate=48000, pad=0.2, use_burgers=False)
+    wave = synthesize_explosion(ordn, geo, atmos, render, world)
+    c0 = float(atmos.speed_of_sound(0.0))
+    src = np.array(geo.source, float)
+    rec = np.array(geo.receiver, float)
+    delay_d = np.linalg.norm(rec - src) / c0
+    src_img = np.array([src[0], src[1], -src[2]])
+    delay_g = np.linalg.norm(rec - src_img) / c0
+    sr = render.sample_rate
+    idx_d = int(delay_d * sr)
+    idx_g = int(delay_g * sr)
+    assert np.abs(wave[idx_d]) > 0
+    assert np.abs(wave[idx_g]) > 0
+
+    hit = world.raycast(tuple(src_img), tuple(rec))
+    vec_inc = np.array(hit.point) - src
+    cos_theta = np.abs(np.dot(vec_inc, hit.normal)) / np.linalg.norm(vec_inc)
+    theta = np.arccos(np.clip(cos_theta, 0.0, 1.0))
+    from ..explosion import _reflection_coefficient
+
+    Rg = _reflection_coefficient(np.array([1000.0]), world.impedance_at(hit.point[0], hit.point[1]), theta)[0]
+    assert abs(Rg) < 1.0

--- a/explosion_audio/tests/test_tv.py
+++ b/explosion_audio/tests/test_tv.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from scipy.ndimage import maximum_filter1d
 from scipy.signal import spectrogram
 
-from explosion import (
+from ..explosion import (
     AtmosphereWT,
     Geometry,
     LinearMotion,
@@ -61,7 +61,7 @@ def test_energy_falloff():
     geo = Geometry(source=src, receiver=rec_motion)
     atmos = AtmosphereWT(rh=0.0)
     render = Rendering(sample_rate=8000, pad=0.2, use_burgers=False)
-    import explosion
+    from .. import explosion
 
     orig_design = explosion.design_absorption_fir
     explosion.design_absorption_fir = lambda D_ref, atmos, sr, taps=512: np.array([1.0])

--- a/explosion_audio/world/__init__.py
+++ b/explosion_audio/world/__init__.py
@@ -1,0 +1,18 @@
+"""World geometry and material utilities."""
+
+from .api import AcousticWorld, Plane, RayHit, Vec3
+from .flat import FlatWorld
+from .materials import Material, MaterialDB, default_materials
+from .tilestreamer import TileStreamer
+
+__all__ = [
+    "AcousticWorld",
+    "Plane",
+    "RayHit",
+    "Vec3",
+    "FlatWorld",
+    "Material",
+    "MaterialDB",
+    "default_materials",
+    "TileStreamer",
+]

--- a/explosion_audio/world/api.py
+++ b/explosion_audio/world/api.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Protocol, Sequence, Tuple
+
+import numpy as np
+
+Vec3 = Tuple[float, float, float]
+
+
+@dataclass(frozen=True)
+class RayHit:
+    """Result of a raycast query in ENU coordinates.
+
+    Parameters are in metres with the ``normal`` vector being unit length.
+    ``distance`` is the segment distance to the hit point or ``np.inf`` if
+    no intersection occurred.
+    """
+
+    hit: bool
+    point: Vec3
+    normal: Vec3
+    material_id: int
+    distance: float
+
+
+@dataclass(frozen=True)
+class Plane:
+    """Infinite plane specified by a point and unit normal (Z-up)."""
+
+    point: Vec3
+    normal: Vec3
+
+
+class AcousticWorld(Protocol):
+    """Minimal interface for terrain and material queries.
+
+    All coordinates follow an ENU, right handed, metres, Z-up convention.
+    """
+
+    def elevation(self, x: float, y: float) -> float:
+        """Return ground elevation ``z`` at ``(x, y)`` in metres."""
+
+    def surface_normal(self, x: float, y: float) -> Vec3:
+        """Return unit surface normal at ``(x, y)`` (default ``(0,0,1)``)."""
+
+    def material_at(self, x: float, y: float) -> int:
+        """Return material identifier at ``(x, y)``."""
+
+    def impedance_at(self, x: float, y: float) -> float:
+        """Return flow resistivity (Pa·s/m²) of material at ``(x, y)``."""
+
+    def raycast(self, p0: Vec3, p1: Vec3) -> RayHit:
+        """Cast a segment from ``p0`` to ``p1`` and return the first hit."""
+
+    def image_surface_candidates(
+        self, src: Vec3, rec: Vec3, max_order: int = 1
+    ) -> Sequence[Plane]:
+        """Return planes to test for image source reflections."""
+
+    def nearest_edges(self, p: Vec3, radius: float) -> Sequence[int]:
+        """Placeholder for diffraction queries (currently empty)."""

--- a/explosion_audio/world/flat.py
+++ b/explosion_audio/world/flat.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple, Optional
+import numpy as np
+
+from .api import AcousticWorld, Plane, RayHit, Vec3
+from .materials import MaterialDB, default_materials
+
+
+def _normalize(v: np.ndarray) -> np.ndarray:
+    n = np.linalg.norm(v)
+    if n == 0:
+        return v
+    return v / n
+
+
+def _ray_plane(p0: np.ndarray, p1: np.ndarray, plane: Plane) -> Tuple[Optional[np.ndarray], float]:
+    """Return intersection point and distance along segment or ``(None, inf)``."""
+    n = np.asarray(plane.normal, float)
+    n = _normalize(n)
+    denom = np.dot(n, p1 - p0)
+    if abs(denom) < 1e-12:
+        return None, np.inf
+    t = np.dot(n, np.asarray(plane.point) - p0) / denom
+    if t < 0.0 or t > 1.0:
+        return None, np.inf
+    point = p0 + t * (p1 - p0)
+    dist = t * np.linalg.norm(p1 - p0)
+    return point, dist
+
+
+@dataclass
+class FlatWorld(AcousticWorld):
+    """Infinite flat ground with optional vertical plane.
+
+    Parameters
+    ----------
+    z0 : float, optional
+        Ground plane height in metres.
+    ground_material_id : int, optional
+        Material id for ground plane.
+    building_plane : Plane, optional
+        Optional second plane (e.g. building facade).
+    building_material_id : int, optional
+        Material id for ``building_plane``.
+    materials : MaterialDB, optional
+        Material database used for impedance lookups.
+    """
+
+    z0: float = 0.0
+    ground_material_id: int = 2
+    building_plane: Plane | None = None
+    building_material_id: int = 2
+    materials: MaterialDB | None = None
+
+    def __post_init__(self) -> None:
+        self.materials = self.materials or default_materials()
+        if self.building_plane is not None:
+            n = np.asarray(self.building_plane.normal, float)
+            n = _normalize(n)
+            self.building_plane = Plane(tuple(self.building_plane.point), tuple(n))
+
+    # -- AcousticWorld interface -------------------------------------------------
+    def elevation(self, x: float, y: float) -> float:
+        return self.z0
+
+    def surface_normal(self, x: float, y: float) -> Vec3:
+        return (0.0, 0.0, 1.0)
+
+    def material_at(self, x: float, y: float) -> int:
+        return self.ground_material_id
+
+    def impedance_at(self, x: float, y: float) -> float:
+        return self.materials.by_id(self.material_at(x, y)).flow_resistivity
+
+    def raycast(self, p0: Vec3, p1: Vec3) -> RayHit:
+        a = np.asarray(p0, float)
+        b = np.asarray(p1, float)
+        planes: list[Tuple[Plane, int]] = [
+            (Plane((0.0, 0.0, self.z0), (0.0, 0.0, 1.0)), self.ground_material_id)
+        ]
+        if self.building_plane is not None:
+            planes.append((self.building_plane, self.building_material_id))
+        best_dist = np.inf
+        best: Tuple[Plane, int, np.ndarray] | None = None
+        for pl, mid in planes:
+            point, dist = _ray_plane(a, b, pl)
+            if point is not None and dist < best_dist:
+                best_dist = dist
+                best = (pl, mid, point)
+        if best is None:
+            return RayHit(False, p1, (0.0, 0.0, 1.0), self.ground_material_id, np.inf)
+        pl, mid, pt = best
+        n = _normalize(np.asarray(pl.normal, float))
+        return RayHit(True, tuple(pt), tuple(n), mid, float(best_dist))
+
+    def image_surface_candidates(self, src: Vec3, rec: Vec3, max_order: int = 1) -> Sequence[Plane]:
+        planes = [Plane((0.0, 0.0, self.z0), (0.0, 0.0, 1.0))]
+        if self.building_plane is not None:
+            planes.append(self.building_plane)
+        return planes
+
+    def nearest_edges(self, p: Vec3, radius: float) -> Sequence[int]:
+        return []

--- a/explosion_audio/world/materials.py
+++ b/explosion_audio/world/materials.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict
+
+@dataclass(frozen=True)
+class Material:
+    """Simple acoustic material description.
+
+    Parameters
+    ----------
+    id : int
+        Identifier used by the world queries.
+    name : str
+        Human readable name.
+    flow_resistivity : float
+        Flow resistivity (Pa·s/m²).
+    absorption_1kHz_db : float, optional
+        1 kHz absorption in decibels. Currently unused.
+    """
+
+    id: int
+    name: str
+    flow_resistivity: float
+    absorption_1kHz_db: float = 0.0
+
+
+@dataclass
+class MaterialDB:
+    """Dictionary style container for :class:`Material` objects."""
+
+    materials: Dict[int, Material]
+
+    def by_id(self, id: int) -> Material:
+        """Return material with ``id``."""
+        return self.materials[id]
+
+
+def default_materials() -> MaterialDB:
+    """Return a default material dictionary."""
+
+    mats = {
+        0: Material(0, "default", 5e4),
+        1: Material(1, "grass/soil", 2e4),
+        2: Material(2, "asphalt/concrete", 1e7),
+        3: Material(3, "water", 5e6),
+    }
+    return MaterialDB(mats)

--- a/explosion_audio/world/tilestreamer.py
+++ b/explosion_audio/world/tilestreamer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from .api import AcousticWorld, Plane, RayHit, Vec3
+from .flat import FlatWorld
+from .materials import MaterialDB, default_materials
+
+
+@dataclass
+class TileStreamer(AcousticWorld):
+    """Stubbed tile streamer that answers the :class:`AcousticWorld` API."""
+
+    tile_size_m: float = 512.0
+    materials: MaterialDB | None = None
+
+    def __post_init__(self) -> None:
+        self.materials = self.materials or default_materials()
+        self._flat = FlatWorld(materials=self.materials)
+
+    # Delegate all API calls to internal FlatWorld tile ----------------------
+    def elevation(self, x: float, y: float) -> float:
+        return self._flat.elevation(x, y)
+
+    def surface_normal(self, x: float, y: float) -> Vec3:
+        return self._flat.surface_normal(x, y)
+
+    def material_at(self, x: float, y: float) -> int:
+        return self._flat.material_at(x, y)
+
+    def impedance_at(self, x: float, y: float) -> float:
+        return self._flat.impedance_at(x, y)
+
+    def raycast(self, p0: Vec3, p1: Vec3) -> RayHit:
+        return self._flat.raycast(p0, p1)
+
+    def image_surface_candidates(self, src: Vec3, rec: Vec3, max_order: int = 1) -> Sequence[Plane]:
+        return self._flat.image_surface_candidates(src, rec, max_order)
+
+    def nearest_edges(self, p: Vec3, radius: float) -> Sequence[int]:
+        return []


### PR DESCRIPTION
## Summary
- introduce AcousticWorld protocol with raycast, impedance and reflection helpers
- add FlatWorld adapter, material database, and TileStreamer stub
- integrate world queries into explosion synthesis and update examples/tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8836e0ea0832fa194df1659f2da89